### PR TITLE
chore: scaffold backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [push]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Run tests
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__/
+*.pyc
+
+# Node
+node_modules/
+.next/
+
+# Environments
+.env
+
+# Misc
+.DS_Store
+backend/pim_backend.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # PIM-PERSO-2025
-pim personnel
+
+Prototype de PIM personnel utilisant FastAPI et Next.js.
+
+## Démarrage
+
+### Backend
+
+```bash
+cd backend
+uvicorn app.main:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="PIM API")
+
+
+class Product(BaseModel):
+    id: int
+    sku: str
+    name: str
+
+
+# Temporary in-memory store
+_products = [
+    Product(id=1, sku="SKU001", name="Example product"),
+]
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/products", response_model=list[Product])
+def list_products() -> list[Product]:
+    return _products

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "pim-backend"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "sqlmodel",
+    "pydantic",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "httpx"]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_list_products():
+    response = client.get("/products")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert data[0]["sku"] == "SKU001"

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pim-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.0.0"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>PIM Frontend</h1>
+      <p>Bienvenue sur le PIM personnel.</p>
+    </main>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add FastAPI backend with health and products endpoints
- scaffold Next.js frontend
- set up GitHub Actions workflow for backend and frontend tests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891cf8d5660833382fd1e8fc6636b94